### PR TITLE
Kiba::Job Mixin

### DIFF
--- a/lib/kiba.rb
+++ b/lib/kiba.rb
@@ -5,6 +5,7 @@ require 'kiba/control'
 require 'kiba/context'
 require 'kiba/parser'
 require 'kiba/runner'
+require 'kiba/job'
 
 Kiba.extend(Kiba::Parser)
 Kiba.extend(Kiba::Runner)

--- a/lib/kiba/job.rb
+++ b/lib/kiba/job.rb
@@ -28,7 +28,8 @@ module Kiba
 
     module InstanceMethods
       def run(options = {})
-        @options = options
+        @options ||= {}
+        @options = @options.merge(options)
         super self.class.control
       end
     end

--- a/lib/kiba/job.rb
+++ b/lib/kiba/job.rb
@@ -1,0 +1,45 @@
+module Kiba
+  module Job
+    module ClassMethods
+      def pre_process(&block)
+        control.pre_processes << { block: block }
+      end
+
+      def source(klass, *initialization_params)
+        control.sources << { klass: klass, args: initialization_params }
+      end
+
+      def transform(klass = nil, *initialization_params, &block)
+        control.transforms << { klass: klass, args: initialization_params, block: block }
+      end
+
+      def destination(klass, *initialization_params)
+        control.destinations << { klass: klass, args: initialization_params }
+      end
+
+      def post_process(&block)
+        control.post_processes << { block: block }
+      end
+
+      def control
+        instance_variable_get(:@control)
+      end
+    end
+
+    module InstanceMethods
+      def run(options = {})
+        @options = options
+        super self.class.control
+      end
+    end
+
+    def self.included(base)
+      base.send :include, Runner
+      base.send :include, InstanceMethods
+      base.send :attr_accessor, :options
+      base.instance_variable_set :@control, Control.new
+      base.extend ClassMethods
+    end
+
+  end
+end

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -1,0 +1,103 @@
+require_relative 'helper'
+
+require_relative 'support/test_csv_source'
+require_relative 'support/test_csv_destination'
+require_relative 'support/test_rename_field_transform'
+require_relative 'support/test_enumerable_source'
+require_relative 'support/test_source_that_reads_at_instantiation_time'
+
+# End-to-end tests go here
+class TestJob < Kiba::Test
+  let(:output_file) { 'test/tmp/output.csv' }
+  let(:input_file) { 'test/tmp/input.csv' }
+
+  let(:sample_csv_data) do
+    <<CSV
+first_name,last_name,sex
+John,Doe,M
+Mary,Johnson,F
+Cindy,Backgammon,F
+Patrick,McWire,M
+CSV
+  end
+
+  def clean
+    remove_files(*Dir['test/tmp/*.csv'])
+  end
+
+  def setup
+    clean
+    IO.write(input_file, sample_csv_data)
+  end
+
+  def teardown
+    clean
+  end
+
+  class CsvToCsvJob # < Kiba::Job
+    include Kiba::Job
+    source TestCsvSource, 'test/tmp/input.csv'
+    transform do |row|
+      row[:sex] = case row[:sex]
+                  when 'M' then 'Male'
+                  when 'F' then 'Female'
+                  else 'Unknown'
+      end
+      row # must be returned
+    end
+    transform do |row|
+      row[:sex] == 'Female' ? row : nil
+    end
+    transform TestRenameFieldTransform, :sex, :sex_2015
+    destination TestCsvDestination, 'test/tmp/output.csv'
+  end
+
+  class VariableAccessJob
+    include Kiba::Job
+    source TestEnumerableSource, [1, 2, 3]
+    def initialize
+      @count = 0 # assign a first value
+    end
+    pre_process do
+      @count += 100 # then change it from there (run time)
+    end
+    transform do |r|
+      @count += 1 # increase it once per row
+      r
+    end
+    def message
+      "Count is now #{@count}"
+    end
+  end
+
+  class FileCreationJob
+    include Kiba::Job
+    pre_process do
+      IO.write('test/tmp/eager.csv', 'something')
+    end
+    source SourceThatReadsAtInstantionTime, 'test/tmp/eager.csv'
+  end
+
+  def test_csv_to_csv
+    CsvToCsvJob.new.run
+
+    # verify the output
+    assert_equal <<CSV, IO.read(output_file)
+first_name,last_name,sex_2015
+Mary,Johnson,Female
+Cindy,Backgammon,Female
+CSV
+  end
+
+  def test_variable_access
+    job = VariableAccessJob.new
+    assert_equal 'Count is now 0', job.message
+    job.run
+    assert_equal 'Count is now 103', job.message
+  end
+
+  def test_file_created_by_pre_process_can_be_read_by_source_at_instantiation_time
+    remove_files('test/tmp/eager.csv')
+    FileCreationJob.new.run
+  end
+end

--- a/test/test_job.rb
+++ b/test/test_job.rb
@@ -100,4 +100,33 @@ CSV
     remove_files('test/tmp/eager.csv')
     FileCreationJob.new.run
   end
+
+  class OptionsAccessJob
+    include Kiba::Job
+    source TestCsvSource, 'test/tmp/input.csv'
+    pre_process do
+      print "pre_process:#{options.inspect}"
+    end
+    transform do |row|
+      print "transform:#{options.inspect}"
+    end
+    post_process do
+      print "post_process:#{options.inspect}"
+    end
+    def initialize(more_options = {})
+      @options ||= {}
+      @options = @options.merge(more_options)
+    end
+  end
+
+
+  def test_options_access
+    real_stdout = $stdout
+    $stdout = StringIO.new
+    OptionsAccessJob.new(a: 1, b: 1).run(b: 2)
+    output = $stdout.string
+    $stdout = real_stdout
+    assert_equal output, "pre_process:{:a=>1, :b=>2}transform:{:a=>1, :b=>2}transform:{:a=>1, :b=>2}transform:{:a=>1, :b=>2}transform:{:a=>1, :b=>2}post_process:{:a=>1, :b=>2}"
+  end
+
 end


### PR DESCRIPTION
Was reviewing some of the thinking over at #18 and decided to take a quick pass on this challenge. This is meant to be less of a formal PR and more of a launching point for a discussion of the best way to implement this functionality.

This PR adds a new module, `Kiba::Job` which can be mixed in to a class and exposes the `run` method which now accepts an optional hash of options which are available to pre_processes, transforms, destinations, and sources, etc.

Here's what it looks like:

``` ruby
class MyJob
  include Kiba::Job

  source MySource

  pre_process do
    # ... access to "options" here
  end

  transform do |row|
    # ... access to "options" here
  end

  post_process do
    # ... access to "options" here
  end
end

job = MyJob.new
job.run some_option: 123
```

All of the tests pass except one, which I may need some help with. In `Runner` I had to modify a few things to check proc/class function arity. 

Additionally, there's a fair amount of duplication in `Context` and `Job` for obvious reasons, but it shouldn't be too hard to combine these.
