### PR TITLE
Add tests around Sidekiq support

### DIFF
--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -14,6 +14,17 @@ class TestParser < Kiba::Test
     assert_equal DummyClass, control.sources[0][:klass]
     assert_equal %w(has args), control.sources[0][:args]
   end
+  
+  # NOTE: useful for anything not using the CLI (e.g. sidekiq)
+  def test_block_parsing_with_reference_to_outside_variable
+    some_variable = Object.new
+    
+    control = Kiba.parse do
+      source DummyClass, some_variable
+    end
+    
+    assert_equal [some_variable], control.sources[0][:args]
+  end
 
   def test_block_transform_definition
     control = Kiba.parse do

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -28,6 +28,7 @@ class TestRunner < Kiba::Test
   end
 
   def test_dismissed_row_not_passed_to_next_transform
+    @called = nil
     control.transforms << { block: lambda { |_| nil } }
     control.transforms << { block: lambda { |_| @called = true; nil } }
     Kiba.run(control)
@@ -43,6 +44,7 @@ class TestRunner < Kiba::Test
   end
 
   def test_post_process_not_called_after_row_failure
+    @called = nil
     control.transforms << { block: lambda { |_| fail 'FAIL' } }
     control.post_processes << { block: lambda { @called = true } }
     assert_raises(RuntimeError, 'FAIL') { Kiba.run(control) }


### PR DESCRIPTION
In the past month I've started using Kiba inside Sidekiq, mostly relying on the fact that one can call `Kiba.parse` and refer to variables declared outside the parsed block. It works great so far.

In the future I'd rather have a clear "scope" where one can pass `locals`, to avoid conflicts, but this still works nicely.