### PR TITLE
Hide Kiba classes from the ETL evaluation scope

### DIFF
--- a/lib/kiba/parser.rb
+++ b/lib/kiba/parser.rb
@@ -1,15 +1,26 @@
-module Kiba
-  module Parser
-    def parse(source_as_string = nil, source_file = nil, &source_as_block)
-      control = Control.new
-      context = Context.new(control)
-      if source_as_string
-        # this somewhat weird construct allows to remove a nil source_file
-        context.instance_eval(*[source_as_string, source_file].compact)
-      else
-        context.instance_eval(&source_as_block)
-      end
-      control
+# NOTE: using the "Kiba::Parser" declaration, as I discovered,
+# provides increased isolation to the declared ETL script, compared
+# to 2 nested modules.
+# Before that, a user creating entities named Control, Context
+# or DSLExtensions would see a conflict with Kiba own classes,
+# as by default instance_eval will resolve references by adding
+# the module containing the parser class (initially "Kiba").
+# Now, the classes appear to be further hidden from the user,
+# as Kiba::Parser is its own module.
+# This allows the user to create a Parser, Context, Control class
+# without it being interpreted as reopening Kiba::Parser, Kiba::Context,
+# etc.
+# See test in test_cli.rb (test_namespace_conflict)
+module Kiba::Parser
+  def parse(source_as_string = nil, source_file = nil, &source_as_block)
+    control = Kiba::Control.new
+    context = Kiba::Context.new(control)
+    if source_as_string
+      # this somewhat weird construct allows to remove a nil source_file
+      context.instance_eval(*[source_as_string, source_file].compact)
+    else
+      context.instance_eval(&source_as_block)
     end
+    control
   end
 end

--- a/test/fixtures/namespace_conflict.etl
+++ b/test/fixtures/namespace_conflict.etl
@@ -1,3 +1,9 @@
-require_relative 'some_extension'
+fail "Context should not be visible without Kiba namespace" if defined?(Context)
+fail "Control should not be visible without Kiba namespace" if defined?(Control)
+fail "Parser should not be visible without Kiba namespace" if defined?(Parser)
+fail "Config should not be visible without Kiba namespace" if defined?(DSLExtensions::Config)
 
+# verify Kiba config (namespaced under Kiba::DSLExtensions::Config)
+# isn't causing troubles to implementers using a top-level DSLExtensions module
+require_relative 'some_extension'
 extend DSLExtensions::SomeExtension

--- a/test/fixtures/namespace_conflict.etl
+++ b/test/fixtures/namespace_conflict.etl
@@ -1,0 +1,3 @@
+require_relative 'some_extension'
+
+extend DSLExtensions::SomeExtension

--- a/test/fixtures/some_extension.rb
+++ b/test/fixtures/some_extension.rb
@@ -1,0 +1,4 @@
+module DSLExtensions
+  module SomeExtension
+  end
+end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -14,4 +14,8 @@ class TestCli < Kiba::Test
     assert_match(/uninitialized constant(.*)UnknownThing/, exception.message)
     assert_includes exception.backtrace.to_s, 'test/fixtures/bogus.etl:2:in'
   end
+
+  def test_namespace_conflict
+    Kiba::Cli.run([fixture('namespace_conflict.etl')])
+  end
 end


### PR DESCRIPTION
While testing Kiba 2.0.0.rc1 on a client codebase, I met a situation where a client-declared module named `DSLExtensions` was shadowed by the new `Kiba::DSLExtensions` containing the new `Config`.

Before this PR, the `Parser` (calling `instance_eval`) was declared like this:

```ruby
module Kiba
  module Parser
  end
end
```

As I discovered, just changing the declaration to this instead:

```ruby
module Kiba::Parser
end
```

seems to hide the Kiba classes further enough to avoid the conflict mentioned above.

I expect that a better blank-slate approach will likely be needed at some point in the future, but this seem to be good enough for the upcoming v2, and will at least make sure that clients using the `DSLExtensions` module to group DSL extensions (very commonly used by my clients) won't see a conflict due to the introduction of `Kiba::DSLExtensions::Config`.