### PR TITLE
Update AppVeyor build configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ cache:
 
 environment:
   matrix:
+    - RUBY_VERSION: 25
     - RUBY_VERSION: 24
     - RUBY_VERSION: 23
     - RUBY_VERSION: 22

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,8 @@ environment:
     - RUBY_VERSION: 21
 
 install:
+  # debugging
+  - dir C:\
   - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
   - bundle config --local path vendor/bundle
   - bundle install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,15 @@ cache:
 
 environment:
   matrix:
-    - RUBY_VERSION: 25
-    - RUBY_VERSION: 24
-    - RUBY_VERSION: 23
-    - RUBY_VERSION: 22
-    - RUBY_VERSION: 21
+    - RUBY_PATH: C:\Ruby25
+    - RUBY_PATH: C:\Ruby24
+    - RUBY_PATH: C:\Ruby23
+    - RUBY_PATH: C:\Ruby22
+    - RUBY_PATH: C:\Ruby21
+    - RUBY_PATH: C:\jruby-9.0.0.0
 
 install:
-  # debugging
-  - dir C:\
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
+  - set PATH=%RUBY_PATH%\bin;%PATH%
   - bundle config --local path vendor/bundle
   - bundle install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,8 @@ cache:
 
 environment:
   matrix:
-    - RUBY_PATH: C:\Ruby25
+    # NOTE: not yet available, will have to install ourselves
+    # - RUBY_PATH: C:\Ruby25
     - RUBY_PATH: C:\Ruby24
     - RUBY_PATH: C:\Ruby23
     - RUBY_PATH: C:\Ruby22


### PR DESCRIPTION
This started as an attempt to run Ruby 2.5, which isn't available as is and will require more work.

I've managed to get a build of JRuby there, using the pre-installed JRuby 9.0.0.0.