### PR TITLE
Fix JRuby 1.9 broken tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,10 @@ require 'minitest/pride'
 require 'minitest/focus'
 require 'kiba'
 
+if ENV['CI'] == 'true'
+  puts "Running with MiniTest version #{MiniTest::VERSION}"
+end
+
 class Kiba::Test < Minitest::Test
   extend Minitest::Spec::DSL
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,4 +15,10 @@ class Kiba::Test < Minitest::Test
   def fixture(file)
     File.join(File.dirname(__FILE__), 'fixtures', file)
   end
+  
+  unless self.method_defined?(:assert_mock)
+    def assert_mock(mock)
+      mock.verify
+    end
+  end
 end


### PR DESCRIPTION
It looks like for JRuby 1.9 only, the tests previously failed because an old version of minitest (5.4.1) is loaded (presumably bundled with JRuby itself), instead of the latest version of minitest (5.1.13).

Link: https://travis-ci.org/thbar/kiba/jobs/378476433

Logs:

```
$ bundle install
Installing minitest 5.11.3

$ bundle exec rake
Running with MiniTest version 5.4.1
```

Since I couldn't find a way to load the latest version with JRuby 1.9, I instead implemented the missing bits in the old version of minitest (`assert_mock`) for now to fix the build.

I will try to provide a full reproduction to the JRuby project - maybe it's a known behaviour by the way.