### PR TITLE
Remove dependency on Minitest::Spec::DSL

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,8 +8,6 @@ if ENV['CI'] == 'true'
 end
 
 class Kiba::Test < Minitest::Test
-  extend Minitest::Spec::DSL
-
   def remove_files(*files)
     files.each do |file|
       File.delete(file) if File.exist?(file)

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -8,10 +8,10 @@ require_relative 'support/test_source_that_reads_at_instantiation_time'
 
 # End-to-end tests go here
 class TestIntegration < Kiba::Test
-  let(:output_file) { 'test/tmp/output.csv' }
-  let(:input_file) { 'test/tmp/input.csv' }
+  def output_file; 'test/tmp/output.csv'; end
+  def input_file; 'test/tmp/input.csv'; end
 
-  let(:sample_csv_data) do
+  def sample_csv_data
     <<CSV
 first_name,last_name,sex
 John,Doe,M


### PR DESCRIPTION
I found this confusing while re-reading some code, so I'm now removing it.