### PR TITLE
Add support for aggregating transforms

### DIFF
--- a/lib/kiba/streaming_runner.rb
+++ b/lib/kiba/streaming_runner.rb
@@ -11,6 +11,11 @@ module Kiba
           end
           y << returned_row if returned_row
         end
+        if t.respond_to?(:close)
+          t.close do |close_row|
+            y << close_row
+          end
+        end
       end
     end
     

--- a/test/support/test_aggregate_transform.rb
+++ b/test/support/test_aggregate_transform.rb
@@ -1,5 +1,5 @@
 class AggregateTransform
-  def initialize(aggregate_size:)
+  def initialize(aggregate_size: 10)
     @aggregate_size = aggregate_size
   end
   

--- a/test/support/test_aggregate_transform.rb
+++ b/test/support/test_aggregate_transform.rb
@@ -1,6 +1,6 @@
 class AggregateTransform
-  def initialize(aggregate_size: 10)
-    @aggregate_size = aggregate_size
+  def initialize(options)
+    @aggregate_size = options.fetch(:aggregate_size)
   end
   
   def process(row)

--- a/test/support/test_aggregate_transform.rb
+++ b/test/support/test_aggregate_transform.rb
@@ -1,0 +1,19 @@
+class AggregateTransform
+  def initialize(aggregate_size:)
+    @aggregate_size = aggregate_size
+  end
+  
+  def process(row)
+    @buffer ||= []
+    @buffer << row
+    if @buffer.size == @aggregate_size
+      yield @buffer
+      @buffer = []
+    end
+    nil
+  end
+  
+  def close
+    yield @buffer unless @buffer.empty?
+  end
+end

--- a/test/support/test_non_closing_transform.rb
+++ b/test/support/test_non_closing_transform.rb
@@ -1,0 +1,5 @@
+class NonClosingTransform
+  def process(row)
+    row
+  end
+end

--- a/test/test_buffering_transform.rb
+++ b/test/test_buffering_transform.rb
@@ -1,0 +1,26 @@
+require_relative 'helper'
+require 'kiba/cli'
+require_relative 'support/test_aggregate_transform'
+require_relative 'support/test_non_closing_transform'
+
+class TestBufferingTransform < Kiba::Test
+  def test_buffering_transform
+    destination_array = []
+    job = Kiba.parse do
+      extend Kiba::DSLExtensions::Config
+      config :kiba, runner: Kiba::StreamingRunner
+
+      source TestEnumerableSource, (1..12)
+      # ensure that a non closing transform won't raise an error
+      transform NonClosingTransform
+      transform AggregateTransform, aggregate_size: 5
+      destination TestArrayDestination, destination_array
+    end
+    Kiba.run(job)
+    assert_equal [
+      [1, 2, 3, 4, 5],
+      [6, 7, 8, 9, 10],
+      [11, 12]
+    ], destination_array
+  end
+end


### PR DESCRIPTION
See #53.

As seen in this [StackOverflow question](https://stackoverflow.com/questions/50868115/etl-to-csv-files-split-up-and-then-pushed-to-s3-to-be-consume-by-redshift/50870997) & other similar situations, it can be helpful to ensure one can aggregate rows together.

This PR introduces an optional `#close` method on transforms, which can either:
- close resources (e.g. a tracing transform could this way close its output file)
- yield one or more rows (e.g. an aggregating transform can provide the last aggregate row to the rest of the pipeline)

Because of the yielding support, you must use the new `StreamingRunner` for this to work:

```ruby
extend Kiba::DSLExtensions::Config
config :kiba, runner: Kiba::StreamingRunner
```

The bundled `AggregateTransform` provides an example of use:

```ruby
class AggregateTransform
  def initialize(aggregate_size:)
    @aggregate_size = aggregate_size
  end
  
  def process(row)
    @buffer ||= []
    @buffer << row
    if @buffer.size == @aggregate_size
      yield @buffer
      @buffer = []
    end
    nil
  end
  
  def close
    yield @buffer unless @buffer.empty?
  end
end
```