### PR TITLE
Enable TruffleRuby-1.0.0-rc6 under TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,26 @@ before_install:
   # https://stackoverflow.com/a/47972768
   - gem update --system
   - gem update bundler
-rvm:
-  - ruby-head
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
-  # NOTE: EOL since 2018-03-31
-  - 2.2
-  # NOTE: EOL since 2017-03-31
-  - 2.1
-  # NOTE: EOL since 2016-02-24
-  - 2.0
-  # NOTE: JRuby 1.7 is now EOL https://github.com/jruby/jruby/issues/4112#issuecomment-346190422
-  - jruby-1.7
-  - jruby-9.1.17.0
+matrix:
+  include:
+    - rvm: ruby-head
+    - rvm: 2.5.1
+    - rvm: 2.4.4
+    - rvm: 2.3.7
+    # NOTE: EOL since 2018-03-31
+    - rvm: 2.2
+    # NOTE: EOL since 2017-03-31
+    - rvm: 2.1
+    # NOTE: EOL since 2016-02-24
+    - rvm: 2.0
+    # NOTE: JRuby 1.7 is now EOL https://github.com/jruby/jruby/issues/4112#issuecomment-346190422
+    - rvm: jruby-1.7
+    - rvm: jruby-9.1.17.0
+    # See https://github.com/oracle/truffleruby/blob/master/doc/user/standalone-distribution.md#testing-truffleruby-in-travisci
+    - rvm: system
+      install:
+        - export TRUFFLERUBY_VERSION=1.0.0-rc6
+        - curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
+        - export PATH="$PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/bin:$PATH"
+        - gem install bundler
+        - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ matrix:
     - rvm: jruby-1.7
     - rvm: jruby-9.1.17.0
     # See https://github.com/oracle/truffleruby/blob/master/doc/user/standalone-distribution.md#testing-truffleruby-in-travisci
-    - rvm: system
+    - name: truffleruby
+      rvm: system
       install:
         - export TRUFFLERUBY_VERSION=1.0.0-rc6
         - curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
-before_install:
-  # https://stackoverflow.com/a/47972768
-  - gem update --system
-  - gem update bundler
+# NOTE: disabled for now, since it seems to cause issues with the TruffleRuby installation trick
+# before_install:
+#   # https://stackoverflow.com/a/47972768
+#   - gem update --system
+#   - gem update bundler
 matrix:
   include:
     - rvm: ruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,9 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/test_*.rb'
 end
 
-task default: :test
+# A simple check to verify TruffleRuby installation trick is really in effect
+task :show_ruby_version do
+  puts "Running with #{RUBY_DESCRIPTION}"
+end
+
+task default: [:show_ruby_version, :test]


### PR DESCRIPTION
Since TruffleRuby support is something I want to ensure (quite useful for ETL work in the end), I'm adding this to the test matrix, using the trick they [currently provide](https://github.com/oracle/truffleruby/blob/master/doc/user/standalone-distribution.md#testing-truffleruby-in-travisci) until TruffleRuby is available on TravisCI for good.

I've also added a log to ensure the Ruby version we think is in use, is actually in use.