### PR TITLE
Fixes issue with accessing methods defined outside of Kiba.parse block.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - name: truffleruby
       rvm: system
       install:
-        - export TRUFFLERUBY_VERSION=1.0.0-rc9
+        - export TRUFFLERUBY_VERSION=1.0.0-rc11
         - curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
         - export PATH="$PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/bin:$PATH"
         - gem install bundler

--- a/lib/kiba/context.rb
+++ b/lib/kiba/context.rb
@@ -1,5 +1,7 @@
 module Kiba
   class Context
+    attr_accessor :block_self
+
     def initialize(control)
       @control = control
     end
@@ -22,6 +24,22 @@ module Kiba
 
     def post_process(&block)
       @control.post_processes << { block: block }
+    end
+
+    def method_missing(method, *args, &block)
+      if block_self
+        block_self.send(method, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method, *)
+      if block_self
+        block_self.respond_to?(method)
+      else
+        super
+      end
     end
   end
 end

--- a/lib/kiba/parser.rb
+++ b/lib/kiba/parser.rb
@@ -19,6 +19,7 @@ module Kiba::Parser
       # this somewhat weird construct allows to remove a nil source_file
       context.instance_eval(*[source_as_string, source_file].compact)
     else
+      context.block_self = eval('self', source_as_block.binding, __FILE__, __LINE__)
       context.instance_eval(&source_as_block)
     end
     control

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -14,16 +14,28 @@ class TestParser < Kiba::Test
     assert_equal DummyClass, control.sources[0][:klass]
     assert_equal %w(has args), control.sources[0][:args]
   end
-  
+
   # NOTE: useful for anything not using the CLI (e.g. sidekiq)
   def test_block_parsing_with_reference_to_outside_variable
     some_variable = Object.new
-    
+
     control = Kiba.parse do
       source DummyClass, some_variable
     end
-    
+
     assert_equal [some_variable], control.sources[0][:args]
+  end
+
+  def some_method
+    'some_method'
+  end
+
+  def test_block_parsing_with_reference_to_outside_method
+    control = Kiba.parse do
+      source DummyClass, some_method
+    end
+
+    assert_equal [some_method], control.sources[0][:args]
   end
 
   def test_block_transform_definition
@@ -59,7 +71,7 @@ class TestParser < Kiba::Test
 
     assert_instance_of Proc, control.post_processes[0][:block]
   end
-  
+
   def test_block_pre_process_definition
     control = Kiba.parse do
       pre_process {}
@@ -100,20 +112,20 @@ RUBY
   ensure
     remove_files('test/tmp/etl-common.rb', 'test/tmp/etl-main.rb')
   end
-  
+
   def test_config
     control = Kiba.parse do
       extend Kiba::DSLExtensions::Config
-      
+
       config :context, key: "value", other_key: "other_value"
     end
-    
+
     assert_equal({ context: {
       key: "value",
       other_key: "other_value"
     }}, control.config)
   end
-  
+
   def test_config_override
     control = Kiba.parse do
       extend Kiba::DSLExtensions::Config
@@ -121,7 +133,7 @@ RUBY
       config :context, key: "value", other_key: "other_value"
       config :context, key: "new_value"
     end
-    
+
     assert_equal({ context: {
       key: "new_value",
       other_key: "other_value"


### PR DESCRIPTION
[This article](https://www.dan-manges.com/blog/ruby-dsls-instance-eval-with-delegation) explains the issue I was running into, along with the general fix. It's a side-effect of using `instance_eval` to create a DSL, which fortunately has a work around.