### PR TITLE
Add source code and documentation links on RubyGems.org

### DIFF
--- a/kiba.gemspec
+++ b/kiba.gemspec
@@ -13,6 +13,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Kiba::VERSION
   gem.executables   = ['kiba']
+  gem.metadata      = {
+    'source_code_uri'   => 'https://github.com/thbar/kiba',
+    'documentation_uri' => 'https://github.com/thbar/kiba/wiki',
+  }
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest', '~> 5.9'


### PR DESCRIPTION
This should add a "Source Code" link on RubyGems.org, which I was missing when looking into Kiba. 

While here, I also changed the "Documentation" link to point to the wiki, as I thought it's more useful than the default rubydoc.info link.

I also wanted to add a [GitHub corner link](https://github.com/tholman/github-corners) to the Kiba website (as it doesn't seem to have a GitHub link atm), but I couldn't find the source code.

