### PR TITLE
Update supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     - rvm: 2.4.5
     # NOTE: EOL since 2019-03-31
     - rvm: 2.3.8
-    # NOTE: JRuby 1.7 is now EOL https://github.com/jruby/jruby/issues/4112#issuecomment-346190422
-    - rvm: jruby-1.7
     - rvm: jruby-9.1.17.0
     - rvm: jruby-9.2.5.0
     - rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,6 @@ matrix:
     - rvm: 2.4.5
     # NOTE: EOL since 2019-03-31
     - rvm: 2.3.8
-    # NOTE: EOL since 2018-03-31
-    - rvm: 2.2
-    # NOTE: EOL since 2017-03-31
-    - rvm: 2.1
-    # NOTE: EOL since 2016-02-24
-    - rvm: 2.0
     # NOTE: JRuby 1.7 is now EOL https://github.com/jruby/jruby/issues/4112#issuecomment-346190422
     - rvm: jruby-1.7
     - rvm: jruby-9.1.17.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - rvm: 2.6.0
     - rvm: 2.5.3
     - rvm: 2.4.5
+    # NOTE: EOL since 2019-03-31
     - rvm: 2.3.8
     # NOTE: EOL since 2018-03-31
     - rvm: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - rvm: 2.4
     # NOTE: EOL since 2019-03-31
     - rvm: 2.3
+    # see https://www.jruby.org/download
     - rvm: jruby-9.1
     - rvm: jruby-9.2
     - rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 matrix:
   include:
+    # see https://www.ruby-lang.org/en/downloads/branches/
     - rvm: ruby-head
     - rvm: 2.6.0
     - rvm: 2.5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ matrix:
   include:
     # see https://www.ruby-lang.org/en/downloads/branches/
     - rvm: ruby-head
-    - rvm: 2.6.0
-    - rvm: 2.5.3
-    - rvm: 2.4.5
+    - rvm: 2.6
+    - rvm: 2.5
+    - rvm: 2.4
     # NOTE: EOL since 2019-03-31
-    - rvm: 2.3.8
-    - rvm: jruby-9.1.17.0
-    - rvm: jruby-9.2.5.0
+    - rvm: 2.3
+    - rvm: jruby-9.1
+    - rvm: jruby-9.2
     - rvm: truffleruby

--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 ------------------------
 
 - Transform's `close` can now yield rows. This is useful to write "aggregating transforms", such as sorting, grouping etc. See [#57](https://github.com/thbar/kiba/pull/57) for more background & explanations.
+- Kiba now requires MRI Ruby 2.3+, JRuby 9.1+ or TruffleRuby.
 
 2.0.0
 -----

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ gem 'kiba'
 
 ## Supported Ruby versions
 
-Kiba currently supports Ruby 2.0+ and JRuby (with its default 1.9 syntax). See [test matrix](https://travis-ci.org/thbar/kiba).
+Kiba currently supports Ruby 2.3+, JRuby 9.1+ and TruffleRuby. See [test matrix](https://travis-ci.org/thbar/kiba).
 
 ## Kiba Common
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ environment:
     - RUBY_VERSION: 25
     - RUBY_VERSION: 24
     - RUBY_VERSION: 23
-    - RUBY_VERSION: 22
     # NOTE: jruby doesn't seem to be supported on default images
     # see https://www.appveyor.com/docs/build-environment/#ruby
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ cache:
 
 environment:
   matrix:
+    - RUBY_VERSION: 26
     - RUBY_VERSION: 25
     - RUBY_VERSION: 24
     - RUBY_VERSION: 23


### PR DESCRIPTION
Kiba now requires MRI Ruby 2.3+, JRuby 9.1+ or TruffleRuby.