### PR TITLE
Avoid bogus "class and block" error message when nil is passed (closes #70)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 - Transform's `close` can now yield rows. This is useful to write "aggregating transforms", such as sorting, grouping etc. See [#57](https://github.com/thbar/kiba/pull/57) for more background & explanations.
 - Kiba now requires MRI Ruby 2.3+, JRuby 9.1+ or TruffleRuby.
+- Fix incorrect error message when calling `transform nil` ([#73](https://github.com/thbar/kiba/pull/73]) - thanks @envygeeks for the report.
 
 2.0.0
 -----

--- a/lib/kiba/runner.rb
+++ b/lib/kiba/runner.rb
@@ -63,15 +63,16 @@ module Kiba
     end
 
     def to_instance(klass, args, block, allow_block, allow_class)
-      if klass
+      if klass && block
+        fail 'Class and block form cannot be used together at the moment'
+      elsif klass
         fail 'Class form is not allowed here' unless allow_class
         klass.new(*args)
       elsif block
         fail 'Block form is not allowed here' unless allow_block
         AliasingProc.new(&block)
-      else
-        # TODO: support block passing to a class form definition?
-        fail 'Class and block form cannot be used together at the moment'
+      elsif
+        fail 'Nil parameters not allowed here'
       end
     end
   end

--- a/test/shared_runner_tests.rb
+++ b/test/shared_runner_tests.rb
@@ -152,4 +152,11 @@ module SharedRunnerTests
       assert_equal [{key: 'value'}], destinations[i].instance_variable_get(:@written_rows)
     end
   end
+
+  def test_nil_transform_error_message
+    control = Kiba.parse do
+      transform
+    end
+    assert_raises(RuntimeError, 'Nil parameters not allowed here') { kiba_run(control) }
+  end
 end


### PR DESCRIPTION
See #70 - calling `transform nil` would give a very confusing message.

This actually hints that it would be better to enforce this earlier, probably at the `Kiba.parse` time, to be able to provide more context to errors, including actual keyword used (source/transform/destination etc), and line numbers.

(I will investigate further on that part, but no hurry at the moment though).