### PR TITLE
Warn about kiba command deprecation (#74)

### DIFF
--- a/lib/kiba/parser.rb
+++ b/lib/kiba/parser.rb
@@ -16,6 +16,7 @@ module Kiba::Parser
     control = Kiba::Control.new
     context = Kiba::Context.new(control)
     if source_as_string
+      puts "WARNING: kiba command will be removed in Kiba v3. See #74. Please migrate to new programmatic API."
       # this somewhat weird construct allows to remove a nil source_file
       context.instance_eval(*[source_as_string, source_file].compact)
     else


### PR DESCRIPTION
See #81 and #74. I'm issuing a preliminary warning (to be published as a late version like "2.9.9").

I will improve it later with the name of the gem to provide backward compatibility, if I publish it.