### PR TITLE
Kiba now defaults to "StreamingRunner" for processing jobs

### DIFF
--- a/lib/kiba.rb
+++ b/lib/kiba.rb
@@ -13,7 +13,7 @@ Kiba.extend(Kiba::Parser)
 module Kiba
   def self.run(job)
     # NOTE: use Hash#dig when Ruby 2.2 reaches EOL
-    runner = job.config.fetch(:kiba, {}).fetch(:runner, Kiba::Runner)
+    runner = job.config.fetch(:kiba, {}).fetch(:runner, Kiba::StreamingRunner)
     runner.run(job)
   end
 end

--- a/test/shared_runner_tests.rb
+++ b/test/shared_runner_tests.rb
@@ -3,10 +3,6 @@ require_relative 'support/test_enumerable_source'
 require_relative 'support/test_destination_returning_nil'
 
 module SharedRunnerTests
-  def kiba_run(job)
-    Kiba.run(job)
-  end
-
   def rows
     @rows ||= [
       { identifier: 'first-row' },

--- a/test/test_run.rb
+++ b/test/test_run.rb
@@ -1,0 +1,12 @@
+require_relative 'helper'
+require 'minitest/mock'
+
+class TestRun < Kiba::Test
+  def test_ensure_kiba_defaults_to_streaming_runner
+    cb = -> (job) { "Streaming runner called" }
+    Kiba::StreamingRunner.stub(:run, cb) do
+      job = Kiba::Control.new
+      assert_equal "Streaming runner called", Kiba.run(job)
+    end
+  end
+end

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -2,5 +2,10 @@ require_relative 'helper'
 require_relative 'shared_runner_tests'
 
 class TestRunner < Kiba::Test
+  def kiba_run(job)
+    job.config[:kiba] = {runner: Kiba::Runner}
+    Kiba.run(job)
+  end
+
   include SharedRunnerTests
 end

--- a/test/test_streaming_runner.rb
+++ b/test/test_streaming_runner.rb
@@ -15,10 +15,6 @@ class TestStreamingRunner < Kiba::Test
     destination_array = []
     
     job = Kiba.parse do
-      extend Kiba::DSLExtensions::Config
-
-      config :kiba, runner: Kiba::StreamingRunner
-
       # provide a single row as the input
       source TestEnumerableSource, [input_row]
 
@@ -51,9 +47,6 @@ class TestStreamingRunner < Kiba::Test
   def test_transform_yielding_from_close
     destination_array = []
     job = Kiba.parse do
-      extend Kiba::DSLExtensions::Config
-      config :kiba, runner: Kiba::StreamingRunner
-
       transform CloseYieldingTransform, yield_on_close: [1, 2]
       destination TestArrayDestination, destination_array
     end
@@ -63,9 +56,6 @@ class TestStreamingRunner < Kiba::Test
 
   def test_transform_with_no_close_must_not_raise
     job = Kiba.parse do
-      extend Kiba::DSLExtensions::Config
-      config :kiba, runner: Kiba::StreamingRunner
-
       transform NonClosingTransform
     end
     Kiba.run(job)

--- a/test/test_streaming_runner.rb
+++ b/test/test_streaming_runner.rb
@@ -8,6 +8,11 @@ require_relative 'support/test_non_closing_transform'
 require_relative 'shared_runner_tests'
 
 class TestStreamingRunner < Kiba::Test
+  def kiba_run(job)
+    job.config[:kiba] = {runner: Kiba::StreamingRunner}
+    Kiba.run(job)
+  end
+
   include SharedRunnerTests
   
   def test_yielding_class_transform


### PR DESCRIPTION
This PR ensures the `StreamingRunner` becomes the default for Kiba v3.0.0.

This change is expected to be backward compatible, but the new runner is more powerful and will be the default in Kiba v3.0.0, so it's time to make it the default.

This will be reflected in the upcoming documentation rewrite (#77).

### What is the `StreamingRunner`?

Kiba v2.0.0 introduced a new "runner" (the code responsible for running the ETL jobs) named `StreamingRunner`.

https://github.com/thbar/kiba/releases/tag/v2.0.0

This runner allows the creation of more powerful and more reusable ETL components.

### Note on legacy `Runner`

It's still possible to revert to the previous `Runner` using configuration like this:

```ruby
Kiba.parse do
  extend Kiba::DSLExtensions::Config
  config :kiba, runner: Kiba::Runner
  # ...
end
```

It is likely, though, that this legacy `Runner` will be removed in Kiba v4.