### PR TITLE
Prepare for Kiba Pro v2.0.0 official release

### DIFF
--- a/COMM-LICENSE.md
+++ b/COMM-LICENSE.md
@@ -177,7 +177,7 @@ The Licensee is responsible for making and keeping adequate backup copies of dat
 
 An active Agreement gives access to “Priority Support”. 
 
-Priority Support covers one (1) email request per quarter. LoGeek will use reasonable endeavours to answer within two (2) French working days. Scope is limited to Kiba and Kiba Pro features and APIs, not the application or infrastructure. For support, email thibaut.barrere+kiba@gmail.com. Please email using the same domain as the original license email or explain your connection to the licensed company. 
+Priority Support covers one (1) email request per quarter. LoGeek will use reasonable endeavours to answer within two (2) French working days. Scope is limited to Kiba and Kiba Pro features and APIs, not the application or infrastructure. For support, email support@logeek.fr. Please email using the same domain as the original license email or explain your connection to the licensed company. 
 
 ## ARTICLE 5 - CUSTOM SUPPORT AND MAINTENANCE
 
@@ -245,7 +245,7 @@ LoGeek is responsible for processing personal data regarding managing contractua
 
 Personal data collected by LoGeek is needed for its processing and is intended for LoGeek’s relevant departments and, where appropriate, its subcontractors and co-contractors, for the requirements of executing the Agreement.
 
-Pursuant to the legal provisions regarding protecting personal data, and under the conditions and to the extent provided by the applicable regulation, each Licensee’s employee concerned shall have a right to query, access, rectify, oppose, obtain erasure or restriction of processing   regarding its personal data – rights which may be exercised by mail sent to the attention of thibaut.barrere+kiba@gmail.com, accompanied, if deemed appropriate by Logeek, by a copy of the relevant person’s identification papers.
+Pursuant to the legal provisions regarding protecting personal data, and under the conditions and to the extent provided by the applicable regulation, each Licensee’s employee concerned shall have a right to query, access, rectify, oppose, obtain erasure or restriction of processing   regarding its personal data – rights which may be exercised by mail sent to the attention of support@logeek.fr, accompanied, if deemed appropriate by Logeek, by a copy of the relevant person’s identification papers.
 
 ## ARTICLE 10 - AUDIT
 

--- a/Pro-Changes.md
+++ b/Pro-Changes.md
@@ -3,10 +3,12 @@ Kiba Pro Changelog
 
 Kiba Pro is the commercial extension for Kiba. Documentation is available on the [Wiki](https://github.com/thbar/kiba/wiki).
 
-HEAD
-----
+2.0.0
+-----
 
 - New: `SQLBulkLookup` transform allows to efficiently lookup values in SQL tables. This is particularly useful in datawarehouse scenarios (to replace unique business keys by surrogate keys), or when writing migrations of SQL databases. Instead of looking-up each row individually, it avoids a "N+1" like effect, by working on large batches of rows.
+- New: `ParallelTransform` provides an easy way to process a group of ETL rows at the same time using a pool of threads. It can be used to accelerate ETL transforms doing IO operations such as HTTP queries, by going multithreaded.
+- New: `FileLock` adds an easy way to avoid overlapping runs in ETL Jobs using a local file lock.
 
 1.5.0
 -----

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Head over to the [Wiki](https://github.com/thbar/kiba/wiki) for up-to-date docum
 
 **If you need help**, please [ask your question with tag kiba-etl on StackOverflow](http://stackoverflow.com/questions/ask?tags=kiba-etl) so that other can benefit from your contribution! I monitor this specific tag and will reply to you.
 
+[Kiba Pro](https://www.kiba-etl.org/kiba-pro) customers get priority private email support.
+
 You can also check out the [author blog](https://thibautbarrere.com) and [StackOverflow answers](http://stackoverflow.com/questions/tagged/kiba-etl).
 
 ## Supported Ruby versions
@@ -23,7 +25,7 @@ Kiba currently supports Ruby 2.4-2.6 ([2.7 support is in preliminary tests](http
 
 **Consulting services**: if your organization needs guidance on Kiba / ETL implementations, we provide consulting services. Contact at [https://www.logeek.fr](https://www.logeek.fr).
 
-**Kiba Pro**: for more features & goodies, check out [Kiba Pro](https://github.com/thbar/kiba/wiki#kiba-pro).
+**Kiba Pro**: for vendor-backed ETL extensions, check out [Kiba Pro](https://www.kiba-etl.org/kiba-pro).
 
 ## License
 


### PR DESCRIPTION
I've refreshed the site at https://www.kiba-etl.org/kiba-pro.

This also updates email references and the changelog.