### PR TITLE
Support block as parameter for "Kiba.run" calls

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 HEAD
 ----
 
-- New: `Kiba.run(job)` can now instead of a job parameter, take a block to define the job. While it is not recommended for general use (jobs should be extracted to modules instead), it is convenient while the initial creation of jobs.
+- New: `Kiba.run(job)` can now (instead of a job parameter) take a block to define the job. While it is not recommended for general use (jobs should be extracted to modules instead), it is convenient during the initial creation of jobs, or for small one-off scripts.
 
 3.5.0
 -----

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+HEAD
+----
+
+- New: `Kiba.run(job)` can now instead of a job parameter, take a block to define the job. While it is not recommended for general use (jobs should be extracted to modules instead), it is convenient while the initial creation of jobs.
+
 3.5.0
 -----
 

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,7 @@
 HEAD
 ----
 
-- New: `Kiba.run(job)` can now (instead of a job parameter) take a block to define the job. While it is not recommended for general use (jobs should be extracted to modules instead), it is convenient during the initial creation of jobs, or for small one-off scripts.
+- New: `Kiba.run(job)` can now (instead of a job parameter) take a block to define the job. See [#94](https://github.com/thbar/kiba/pull/94) for more details.
 
 3.5.0
 -----

--- a/lib/kiba.rb
+++ b/lib/kiba.rb
@@ -11,7 +11,13 @@ require 'kiba/dsl_extensions/config'
 Kiba.extend(Kiba::Parser)
 
 module Kiba
-  def self.run(job)
+  def self.run(job = nil, &block)
+    unless (job.nil? ^ block.nil?)
+      fail ArgumentError.new("Kiba.run takes either one argument (the job) or a block (defining the job)")
+    end
+
+    job ||= Kiba.parse { instance_exec(&block) }
+
     # NOTE: use Hash#dig when Ruby 2.2 reaches EOL
     runner = job.config.fetch(:kiba, {}).fetch(:runner, Kiba::StreamingRunner)
     runner.run(job)

--- a/test/test_run.rb
+++ b/test/test_run.rb
@@ -1,5 +1,7 @@
 require_relative 'helper'
 require 'minitest/mock'
+require_relative 'support/test_enumerable_source'
+require_relative 'support/test_array_destination'
 
 class TestRun < Kiba::Test
   def test_ensure_kiba_defaults_to_streaming_runner
@@ -7,6 +9,30 @@ class TestRun < Kiba::Test
     Kiba::StreamingRunner.stub(:run, cb) do
       job = Kiba::Control.new
       assert_equal "Streaming runner called", Kiba.run(job)
+    end
+  end
+
+  def test_run_allows_block_arg
+    rows = []
+    Kiba.run do
+      source TestEnumerableSource, (1..10)
+      destination TestArrayDestination, rows
+    end
+    assert_equal (1..10).to_a, rows
+  end
+
+  def test_forbids_no_arg
+    assert_raises ArgumentError do
+      Kiba.run
+    end
+  end
+
+  def test_forbids_multiple_args
+    assert_raises ArgumentError do
+      job = Kiba.parse { }
+      Kiba.run(job) do
+        #
+      end
     end
   end
 end


### PR DESCRIPTION
The usual way to create a Kiba job these days is:

```ruby
module ETL
  module MyJob
    module_function

    def setup(config)
      Kiba.parse do
        # SNIP (job definition)
      end
    end
  end
end
```

Then one would invoke it with:

```ruby
Kiba.run(ETL::MyJob.setup(config))
```

On occasions, though (e.g. one-off scripts, or during initial prototyping) it can be useful to avoid that and just work inline:

```ruby
Kiba.run(Kiba.parse do
  # SNIP (job definition)
end)
```

This PR introduces a shortcut for this type of work, where you can just run the job with:

```ruby
Kiba.run do
  # SNIP (job definition)
end
```