### PR TITLE
Update CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   include:
     # see https://www.ruby-lang.org/en/downloads/branches/
     - rvm: ruby-head
+    - rvm: 3.0
     - rvm: 2.7
     - rvm: 2.6
     - rvm: 2.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,11 @@ cache:
 
 environment:
   matrix:
+    # TODO: add RUBY_VERSION=30 when available (https://www.appveyor.com/updates/)
+    - RUBY_VERSION: 27
     - RUBY_VERSION: 26
     - RUBY_VERSION: 25
     - RUBY_VERSION: 24
-    - RUBY_VERSION: 23
     # NOTE: jruby doesn't seem to be supported on default images
     # see https://www.appveyor.com/docs/build-environment/#ruby
 


### PR DESCRIPTION
* Explicit testing of Ruby 3 (although it was already tested more or less via `ruby-head` so far)
* Updates for AppVeyor (Windows testing ; removal of Ruby 2.3, attempt to add Ruby 2.7, but [failing](https://ci.appveyor.com/project/thbar/kiba/builds/37137172/job/vnwc71yamfrs22hc) so far)