### PR TITLE
Fix standardrb errors + minitest references in tests 

### DIFF
--- a/kiba.gemspec
+++ b/kiba.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "awesome_print"
   gem.add_development_dependency "minitest-focus"
   gem.add_development_dependency "standard"
+  gem.add_development_dependency "csv"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,7 +4,7 @@ require "minitest/focus"
 require "kiba"
 
 if ENV["CI"] == "true"
-  puts "Running with MiniTest version #{MiniTest::VERSION}"
+  puts "Running with Minitest version #{Minitest::VERSION}"
 end
 
 class Kiba::Test < Minitest::Test

--- a/test/shared_runner_tests.rb
+++ b/test/shared_runner_tests.rb
@@ -64,7 +64,7 @@ module SharedRunnerTests
   def test_pre_process_runs_before_source_is_instantiated
     calls = []
 
-    mock_source_class = MiniTest::Mock.new
+    mock_source_class = Minitest::Mock.new
     mock_source_class.expect(:new, TestEnumerableSource.new([1, 2, 3])) do
       calls << :source_instantiated
     end
@@ -80,9 +80,9 @@ module SharedRunnerTests
 
   def test_no_error_raised_if_destination_close_not_implemented
     # NOTE: this fake destination does not implement `close`
-    destination_instance = MiniTest::Mock.new
+    destination_instance = Minitest::Mock.new
 
-    mock_destination_class = MiniTest::Mock.new
+    mock_destination_class = Minitest::Mock.new
     mock_destination_class.expect(:new, destination_instance)
 
     control = Kiba::Control.new
@@ -92,9 +92,9 @@ module SharedRunnerTests
   end
 
   def test_destination_close_called_if_defined
-    destination_instance = MiniTest::Mock.new
+    destination_instance = Minitest::Mock.new
     destination_instance.expect(:close, nil)
-    mock_destination_class = MiniTest::Mock.new
+    mock_destination_class = Minitest::Mock.new
     mock_destination_class.expect(:new, destination_instance)
 
     control = Kiba::Control.new

--- a/test/support/shared_tests.rb
+++ b/test/support/shared_tests.rb
@@ -4,7 +4,7 @@ module SharedTests
     @@shared_tests[desc] = block
   end
 
-  def shared_tests(desc, *args)
-    class_exec(*args, &@@shared_tests.fetch(desc))
+  def shared_tests(desc, *)
+    class_exec(*, &@@shared_tests.fetch(desc))
   end
 end

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -55,7 +55,7 @@ class TestIntegration < Kiba::Test
 
       # returning nil dismisses the row
       transform do |row|
-        row[:sex] == "Female" ? row : nil
+        (row[:sex] == "Female") ? row : nil
       end
 
       transform TestRenameFieldTransform, :sex, :sex_2015

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -55,7 +55,7 @@ class TestIntegration < Kiba::Test
 
       # returning nil dismisses the row
       transform do |row|
-        (row[:sex] == "Female") ? row : nil
+        row[:sex] == "Female" ? row : nil
       end
 
       transform TestRenameFieldTransform, :sex, :sex_2015


### PR DESCRIPTION
In this PR:
- fix backward incompatible minitest references
- standardrb errors on latest rubies
- "csv" development dependency support